### PR TITLE
Quick fix [golang/go/issues/6113]

### DIFF
--- a/colly/sqlite3/sqlite3.go
+++ b/colly/sqlite3/sqlite3.go
@@ -112,7 +112,9 @@ func (s *Storage) Visited(requestID uint64) error {
 	if err != nil {
 		return err
 	}
-	_, err = statement.Exec(requestID)
+    // [golang/go/issues/6113] we can't use uint64 with the high bit set 
+    // but we can cast it and store as an int64 without data loss
+	_, err = statement.Exec(int64(requestID))
 	if err != nil {
 		return err
 	}
@@ -126,7 +128,9 @@ func (s *Storage) IsVisited(requestID uint64) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	row := statement.QueryRow(requestID)
+    // [golang/go/issues/6113] we can't use uint64 with the high bit set 
+    // but we can cast it and store as an int64 without data loss
+	row := statement.QueryRow(int64(requestID))
 	err = row.Scan(&count)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
At the moment we're basically unable to visit half URLs because they have a hash with a high bit set.

My solution is to convert it to int64 so we can store and get those values without an issue.

func TestUint64(t *testing.T) {
	var i uint64 = 11351424885521755839
	println(int64(i)) // -7095319188187795777
}