### PR TITLE
fix(concurrency): Prevent concurrent writes

### DIFF
--- a/colly/sqlite3/sqlite3.go
+++ b/colly/sqlite3/sqlite3.go
@@ -108,6 +108,9 @@ func (s *Storage) Close() error {
 
 // Visited implements colly/storage.Visited()
 func (s *Storage) Visited(requestID uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	
 	statement, err := s.dbh.Prepare("INSERT INTO visited (requestID, visited) VALUES (?, 1)")
 	if err != nil {
 		return err
@@ -194,6 +197,9 @@ func (s *Storage) Cookies(u *url.URL) string {
 
 // AddRequest implements queue.Storage.AddRequest() function
 func (s *Storage) AddRequest(r []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	
 	//return s.Client.RPush(s.getQueueID(), r).Err()
 	statement, err := s.dbh.Prepare("INSERT INTO queue (data) VALUES (?)")
 	if err != nil {


### PR DESCRIPTION
We can only write from one thread at a time. Prevent concurrent writes by taking a lock before trying to write.